### PR TITLE
Remove ES6 arrow function shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const md5Hex = require('md5-hex');
 
 const BASE_URL = 'https://gravatar.com/avatar/';
 
-module.exports = (email, opts) => {
+module.exports = function (email, opts) {
 	if (email.indexOf('@') === -1) {
 		throw new Error('Please specify an email');
 	}


### PR DESCRIPTION
If this module is used in a browser *without compiling with babel* most older browsers will break (for example, IE 11).

This change replaces the new es6 arrow function shorthand with the old approach. Obviously, it's not as nice, but alas it works in all browsers.