### PR TITLE
Fix type for `default` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,11 +9,11 @@ export interface Options {
 	readonly size?: number;
 
 	/**
-	[Image](https://en.gravatar.com/site/implement/images/#default-image) to return if the identifier didn't match any Gravatar profile. Either a custom URL or [`404`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=404), [`mm`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=mm), [`identicon`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=identicon), [`monsterid`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=monsterid), [`wavatar`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=wavatar), [`retro`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=retro), [`blank`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=blank).
+	[Image](https://en.gravatar.com/site/implement/images/#default-image) to return if the identifier didn't match any Gravatar profile. Either a custom URL or [`404`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=404), [`mp`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=mp), [`identicon`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=identicon), [`monsterid`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=monsterid), [`wavatar`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=wavatar), [`retro`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=retro), [`blank`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=blank).
 
 	@default 'https://gravatar.com/avatar/00000000000000000000000000000000'
 	*/
-	readonly default?: LiteralUnion<'404' | 'mm' | 'identicon' | 'monsterid' | 'wavatar' | 'retro' | 'blank', string>;
+	readonly default?: LiteralUnion<'404' | 'mp' | 'identicon' | 'monsterid' | 'wavatar' | 'retro' | 'blank', string>;
 
 	/**
 	Allowed [rating](https://en.gravatar.com/site/implement/images/#rating) of the image.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ expectType<string>(gravatarUrl('sindresorhus@gmail.com', {default: 'blank'}));
 expectType<string>(
 	gravatarUrl('sindresorhus@gmail.com', {default: 'identicon'})
 );
-expectType<string>(gravatarUrl('sindresorhus@gmail.com', {default: 'mm'}));
+expectType<string>(gravatarUrl('sindresorhus@gmail.com', {default: 'mp'}));
 expectType<string>(
 	gravatarUrl('sindresorhus@gmail.com', {default: 'monsterid'})
 );

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Values: `1..2048`
 
 Type: `string`\
 Default: [This image](https://gravatar.com/avatar/00000000000000000000000000000000)\
-Values: Custom URL or [`404`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=404), [`mm`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=mm), [`identicon`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=identicon), [`monsterid`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=monsterid), [`wavatar`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=wavatar), [`retro`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=retro), [`blank`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=blank)
+Values: Custom URL or [`404`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=404), [`mp`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=mp), [`identicon`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=identicon), [`monsterid`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=monsterid), [`wavatar`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=wavatar), [`retro`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=retro), [`blank`](https://gravatar.com/avatar/5cc22f8c06631cccead907acbb627b69?default=blank)
 
 [Image](https://en.gravatar.com/site/implement/images/#default-image) to return if the identifier didn't match any Gravatar profile.
 


### PR DESCRIPTION
Updated to reflect the current [docs](https://docs.gravatar.com/api/avatars/images/#default-image). It’s now mystery-_person_.

**NOTE**: the API still returns an image if you use `mm`.

---

💖